### PR TITLE
Add: delete functionality

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import type { LoanApplication } from './types/loan'
-import { getLoans, updateLoanStatus, autoDecideLoan } from './services/loanService'
+import { getLoans, updateLoanStatus, autoDecideLoan, deleteLoan } from './services/loanService'
 import LoanForm from './components/LoanForm.vue'
 import LoanList from './components/LoanList.vue'
 import LoanSummary from './components/LoanSummary.vue'
@@ -27,6 +27,11 @@ function handleAutoDecide(id: string) {
   refreshLoans()
 }
 
+function handleDelete(id: string) {
+  deleteLoan(id)
+  refreshLoans()
+}
+
 onMounted(() => {
   refreshLoans()
 })
@@ -49,6 +54,7 @@ onMounted(() => {
         @approve="handleApprove"
         @reject="handleReject"
         @auto-decide="handleAutoDecide"
+        @delete="handleDelete"
       />
     </main>
   </div>

--- a/src/components/LoanList.vue
+++ b/src/components/LoanList.vue
@@ -10,7 +10,15 @@ const emit = defineEmits<{
   approve: [id: string]
   reject: [id: string]
   autoDecide: [id: string]
+  delete: [id: string]
 }>()
+
+function handleDelete(id: string) {
+  const confirmed = window.confirm('Are you sure you want to delete this loan application? This action cannot be undone.')
+  if (confirmed) {
+    emit('delete', id)
+  }
+}
 
 function formatCurrency(value: number): string {
   return new Intl.NumberFormat('en-US', {
@@ -94,7 +102,13 @@ function formatDate(isoDate: string): string {
               >
                 ⚡
               </button>
-              <span v-if="loan.status !== 'pending'" class="no-actions">—</span>
+              <button
+                class="action-btn danger"
+                @click="handleDelete(loan.id)"
+                title="Delete"
+              >
+                🗑
+              </button>
             </td>
           </tr>
         </tbody>

--- a/src/services/loanService.ts
+++ b/src/services/loanService.ts
@@ -124,7 +124,6 @@ export function autoDecideLoan(id: string): void {
 export function deleteLoan(id: string): void {
   const loans = getLoans()
   const loanIndex = loans.findIndex(loan => loan.id === id)
-  
   if (loanIndex === -1) {
     throw new Error(`Loan with id ${id} not found`)
   }

--- a/src/services/loanService.ts
+++ b/src/services/loanService.ts
@@ -116,3 +116,19 @@ export function autoDecideLoan(id: string): void {
 
   saveLoans(loans)
 }
+
+/**
+ * Delete a loan by ID
+ * Removes the loan from the array and updates localStorage
+ */
+export function deleteLoan(id: string): void {
+  const loans = getLoans()
+  const loanIndex = loans.findIndex(loan => loan.id === id)
+  
+  if (loanIndex === -1) {
+    throw new Error(`Loan with id ${id} not found`)
+  }
+
+  loans.splice(loanIndex, 1)
+  saveLoans(loans)
+}

--- a/tests/loanService.test.ts
+++ b/tests/loanService.test.ts
@@ -5,7 +5,8 @@ import {
   createLoanApplication,
   updateLoanStatus,
   calculateMonthlyPayment,
-  autoDecideLoan
+  autoDecideLoan,
+  deleteLoan
 } from '../src/services/loanService'
 import type { LoanApplication } from '../src/types/loan'
 
@@ -325,6 +326,107 @@ describe('loanService', () => {
       expect(() => autoDecideLoan('non-existent')).toThrow(
         'Loan with id non-existent not found'
       )
+    })
+  })
+
+  describe('deleteLoan', () => {
+    it('deletes a loan by id', () => {
+      const loans: LoanApplication[] = [
+        {
+          id: '1',
+          applicantName: 'John Doe',
+          amount: 50000,
+          termMonths: 24,
+          interestRate: 0.08,
+          status: 'pending',
+          createdAt: '2024-01-01T00:00:00.000Z'
+        },
+        {
+          id: '2',
+          applicantName: 'Jane Smith',
+          amount: 75000,
+          termMonths: 36,
+          interestRate: 0.06,
+          status: 'approved',
+          createdAt: '2024-02-01T00:00:00.000Z'
+        }
+      ]
+      saveLoans(loans)
+
+      deleteLoan('1')
+
+      const remainingLoans = getLoans()
+      expect(remainingLoans).toHaveLength(1)
+      expect(remainingLoans[0]?.id).toBe('2')
+    })
+
+    it('updates localStorage after deletion', () => {
+      const loans: LoanApplication[] = [
+        {
+          id: '1',
+          applicantName: 'John Doe',
+          amount: 50000,
+          termMonths: 24,
+          interestRate: 0.08,
+          status: 'pending',
+          createdAt: '2024-01-01T00:00:00.000Z'
+        }
+      ]
+      saveLoans(loans)
+      vi.clearAllMocks()
+
+      deleteLoan('1')
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'tredgate_loans',
+        JSON.stringify([])
+      )
+    })
+
+    it('throws error when loan not found', () => {
+      expect(() => deleteLoan('non-existent')).toThrow(
+        'Loan with id non-existent not found'
+      )
+    })
+
+    it('deletes only the specified loan', () => {
+      const loans: LoanApplication[] = [
+        {
+          id: '1',
+          applicantName: 'First',
+          amount: 10000,
+          termMonths: 12,
+          interestRate: 0.05,
+          status: 'pending',
+          createdAt: '2024-01-01T00:00:00.000Z'
+        },
+        {
+          id: '2',
+          applicantName: 'Second',
+          amount: 20000,
+          termMonths: 24,
+          interestRate: 0.06,
+          status: 'approved',
+          createdAt: '2024-02-01T00:00:00.000Z'
+        },
+        {
+          id: '3',
+          applicantName: 'Third',
+          amount: 30000,
+          termMonths: 36,
+          interestRate: 0.07,
+          status: 'rejected',
+          createdAt: '2024-03-01T00:00:00.000Z'
+        }
+      ]
+      saveLoans(loans)
+
+      deleteLoan('2')
+
+      const remainingLoans = getLoans()
+      expect(remainingLoans).toHaveLength(2)
+      expect(remainingLoans[0]?.id).toBe('1')
+      expect(remainingLoans[1]?.id).toBe('3')
     })
   })
 })


### PR DESCRIPTION
This pull request adds the ability to delete loan applications from the app. The main changes include implementing the `deleteLoan` function in the service layer, integrating loan deletion into the UI with confirmation, and adding comprehensive tests for the new functionality.

**Feature: Loan Deletion**

* Added a new `deleteLoan` function to `loanService.ts` that removes a loan by ID and updates localStorage. Throws an error if the loan is not found.
* Integrated loan deletion into the UI: added a "Delete" button to each loan entry in `LoanList.vue`, which prompts for confirmation before emitting a delete event. [[1]](diffhunk://#diff-1352f3663cdd969ee28a168dcb23242a136ad4e7e564e578c78a432917255f8cL97-R111) [[2]](diffhunk://#diff-1352f3663cdd969ee28a168dcb23242a136ad4e7e564e578c78a432917255f8cR13-R22)
* Connected the delete event from `LoanList.vue` to a handler in `App.vue` that calls `deleteLoan` and refreshes the loan list. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R30-R34) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R57) [[3]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L4-R4)

**Testing**

* Added a suite of tests for `deleteLoan` in `loanService.test.ts`, covering loan removal, localStorage update, error handling, and correct deletion of only the specified loan. [[1]](diffhunk://#diff-d5932355fcc75b580d6f49de6f1da90c33a9847325152bf2a5bbf3a1991a3464R331-R431) [[2]](diffhunk://#diff-d5932355fcc75b580d6f49de6f1da90c33a9847325152bf2a5bbf3a1991a3464L8-R9)